### PR TITLE
Implement CD for launchpad and symphony parsing logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ bin/
 
 # Goreleaser
 dist/
+
+# Local dev, configs etc
+local/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "zerefdev.todo-highlighter",
+    "golang.go",
+    "github.vscode-pull-request-github"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,30 +5,6 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Debug CLI",
-      "type": "go",
-      "request": "launch",
-      "mode": "auto",
-      "program": "${workspaceFolder}",
-      "args": [
-        "clone",
-        "--repo",
-        "foo/bar"
-      ]
-    },
-    {
-      "name": "Debug login CLI",
-      "type": "go",
-      "request": "launch",
-      "mode": "auto",
-      "program": "${workspaceFolder}",
-      "args": [
-        "login",
-        "--use_msi",
-        "true"
-      ]
-    },
-    {
       "name": "Debug CI CLI",
       "type": "go",
       "request": "launch",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,4 @@
 {
-  "todoHighlighter.include": ["**/*.go"],
-  "go.useLanguageServer": true,
-  "go.lintTool": "golangci-lint",
-  "[go]": {
-    "editor.defaultFormatter": "golang.go",
-    "editor.formatOnSave": true,
-    "editor.codeActionsOnSave": {
-      "source.organizeImports": true
-    }
-  }
+  // There's many TODO: comments scatted in the code, this is useful extension to help manage them
+  "todoHighlighter.include": ["**/*.go"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "todoHighlighter.include": ["**/*.go"],
+  "go.useLanguageServer": true,
+  "go.lintTool": "golangci-lint",
+  "[go]": {
+    "editor.defaultFormatter": "golang.go",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": true
+    }
+  }
+}

--- a/cmd/cd.go
+++ b/cmd/cd.go
@@ -22,7 +22,7 @@ var cdCmd = &cobra.Command{
 	Short: "Manage CD operations.",
 	Long:  `Manage CD operations.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		levelInt, _ := cmd.Flags().GetInt("level")
+		levelFlag, _ := cmd.Flags().GetString("level")
 		configPath, _ := cmd.Flags().GetString("symphony-config")
 		actionStr, _ := cmd.Flags().GetString("action")
 		action, err := landingzone.NewAction(actionStr)
@@ -31,19 +31,15 @@ var cdCmd = &cobra.Command{
 		conf, err := symphony.NewSymphonyConfig(configPath)
 		cobra.CheckErr(err)
 
-		if levelInt == allLevels {
+		if levelFlag == "" {
 			conf.RunAll(action)
 			return
 		}
 
-		if levelInt < allLevels {
-			cobra.CheckErr("Level must be greater than zero")
-		}
-
 		var level *symphony.Level
-		// Try to locate level in config from int
+		// Try to locate level in config matching the level flag passed in
 		for _, confLevel := range conf.Levels {
-			if confLevel.Number == levelInt {
+			if confLevel.Name == levelFlag {
 				level = &confLevel
 				break
 			}
@@ -51,7 +47,7 @@ var cdCmd = &cobra.Command{
 
 		//nolint
 		if level == nil {
-			cobra.CheckErr(fmt.Sprintf("level '%d' not found in symphony config file", levelInt))
+			cobra.CheckErr(fmt.Sprintf("level '%s' not found in symphony config file", levelFlag))
 		}
 		//nolint
 		conf.RunLevel(*level, action)
@@ -61,7 +57,7 @@ var cdCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(cdCmd)
 	cdCmd.Flags().StringP("symphony-config", "c", "", "Path to symphony config file")
-	cdCmd.Flags().IntP("level", "l", allLevels, "Level to operate on")
+	cdCmd.Flags().StringP("level", "l", "", "Level to operate on, if omitted all levels will be processed")
 	landingzone.AddActionFlag(cdCmd)
 
 	_ = cobra.MarkFlagRequired(cdCmd.Flags(), "symphony-config")

--- a/cmd/cd.go
+++ b/cmd/cd.go
@@ -9,8 +9,12 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/aztfmod/rover/pkg/landingzone"
+	"github.com/aztfmod/rover/pkg/symphony"
 	"github.com/spf13/cobra"
 )
+
+const allLevels = -1
 
 // cdCmd represents the cd command
 var cdCmd = &cobra.Command{
@@ -18,10 +22,47 @@ var cdCmd = &cobra.Command{
 	Short: "Manage CD operations.",
 	Long:  `Manage CD operations.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("cd called")
+		levelInt, _ := cmd.Flags().GetInt("level")
+		configPath, _ := cmd.Flags().GetString("symphony-config")
+		actionStr, _ := cmd.Flags().GetString("action")
+		action, err := landingzone.NewAction(actionStr)
+		cobra.CheckErr(err)
+
+		conf, err := symphony.NewSymphonyConfig(configPath)
+		cobra.CheckErr(err)
+
+		if levelInt == allLevels {
+			conf.RunAll(action)
+			return
+		}
+
+		if levelInt < allLevels {
+			cobra.CheckErr("Level must be greater than zero")
+		}
+
+		var level *symphony.Level
+		// Try to locate level in config from int
+		for _, confLevel := range conf.Levels {
+			if confLevel.Number == levelInt {
+				level = &confLevel
+				break
+			}
+		}
+
+		//nolint
+		if level == nil {
+			cobra.CheckErr(fmt.Sprintf("level '%d' not found in symphony config file", levelInt))
+		}
+		//nolint
+		conf.RunLevel(*level, action)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(cdCmd)
+	cdCmd.Flags().StringP("symphony-config", "c", "", "Path to symphony config file")
+	cdCmd.Flags().IntP("level", "l", allLevels, "Level to operate on")
+	landingzone.AddActionFlag(cdCmd)
+
+	_ = cobra.MarkFlagRequired(cdCmd.Flags(), "symphony-config")
 }

--- a/cmd/cd.go
+++ b/cmd/cd.go
@@ -14,8 +14,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const allLevels = -1
-
 // cdCmd represents the cd command
 var cdCmd = &cobra.Command{
 	Use:   "cd",

--- a/cmd/landingzone_run.go
+++ b/cmd/landingzone_run.go
@@ -8,6 +8,7 @@
 package cmd
 
 import (
+	"github.com/aztfmod/rover/pkg/console"
 	"github.com/aztfmod/rover/pkg/landingzone"
 	"github.com/spf13/cobra"
 )
@@ -16,7 +17,12 @@ var lzRunCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run actions to deploy, update or remove landing zones",
 
-	Run: landingzone.RunCmd,
+	// TODO: Implement this, not working but will us the same shared RunFunc as lp run
+	// See task #21
+	//Run: landingzone.RunFunc,
+	Run: func(cmd *cobra.Command, args []string) {
+		console.Error("landingzone run command is not implemented yet")
+	},
 }
 
 func init() {

--- a/cmd/launchpad_run.go
+++ b/cmd/launchpad_run.go
@@ -16,7 +16,7 @@ var lpRunCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run actions to deploy, update or remove launchpads",
 
-	Run: landingzone.RunCmd,
+	Run: landingzone.RunFunc,
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/aztfmod/rover/pkg/console"
+	"github.com/aztfmod/rover/pkg/version"
 	"github.com/spf13/cobra"
 
 	"github.com/spf13/viper"
@@ -32,9 +33,13 @@ to make sure that all contributors in the GitOps teams are using a consistent se
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute(version string) {
-	rootCmd.Version = version
+func Execute() {
+	rootCmd.Version = version.Value
 	cobra.CheckErr(rootCmd.Execute())
+}
+
+func GetVersion() string {
+	return rootCmd.Version
 }
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/briandowns/spinner v1.13.0
-	github.com/davecgh/go-spew v1.1.1
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-exec v0.13.3
 	github.com/spf13/cobra v1.1.3

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,13 @@ require (
 	github.com/Azure/azure-storage-blob-go v0.13.0
 	github.com/Azure/go-autorest/autorest v0.11.18
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.7
+	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
+	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/briandowns/spinner v1.13.0
-	github.com/hashicorp/go-azure-helpers v0.16.0
+	github.com/davecgh/go-spew v1.1.1
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-exec v0.13.3
 	github.com/spf13/cobra v1.1.3
-	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
 	golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea // indirect
 	golang.org/x/tools v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -162,10 +162,7 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-azure-helpers v0.16.0 h1:f8LqrmC7K545DSk9EvymtuiFZ8tlTC7+XkvmAZmUeiM=
-github.com/hashicorp/go-azure-helpers v0.16.0/go.mod h1:kR7+sTDEb9TOp/O80ss1UEJg1t4/BHLD/U8wHLS4BGQ=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -176,7 +173,6 @@ github.com/hashicorp/go-getter v1.5.3 h1:NF5+zOlQegim+w/EUhSLh6QhXHmZMEeHLQzllkQ
 github.com/hashicorp/go-getter v1.5.3/go.mod h1:BrrV/1clo8cCYu6mxvboYg+KutTiFnXjMEgDD8+i7ZI=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
-github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
@@ -187,7 +183,6 @@ github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
 github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
@@ -363,7 +358,6 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
-golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/main.go
+++ b/main.go
@@ -10,9 +10,6 @@ import (
 	"github.com/aztfmod/rover/cmd"
 )
 
-// Have to put version here or ldflags can't set it ¯\_(ツ)_/¯
-var version = "0.0.0"
-
 func main() {
-	cmd.Execute(version)
+	cmd.Execute()
 }

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.0.1
+VERSION ?= 2.0.1
 
 .PHONY: build help lint lint-fix run test clean
 .DEFAULT_GOAL := help
@@ -19,7 +19,7 @@ lint-fix: ## 🌟 Lint & format, will try to fix errors and modify code
 	$(GOLINT_PATH) run --modules-download-mode=mod ./... --fix
 
 build: ## 🔨 Build the rover binary
-	go build -ldflags "-X main.version='$(VERSION)'" -o bin/rover 
+	go build -ldflags "-X github.com/aztfmod/rover/pkg/version.Value='$(VERSION)'" -o bin/rover 
 
 run: ## 🏃‍ Run locally
 	go run main.go $(ARGS)

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -2,10 +2,19 @@ package console
 
 import (
 	"fmt"
+	"time"
+
+	"github.com/briandowns/spinner"
 )
 
-// DebugEnabled controls output of debug messages
+// DebugEnabled controls output of debug messages and the spinner
 var DebugEnabled = false
+var consoleSpinner *spinner.Spinner
+
+func init() {
+	// See https://github.com/briandowns/spinner#available-character-sets
+	consoleSpinner = spinner.New(spinner.CharSets[37], 100*time.Millisecond)
+}
 
 // Debug outputs strings if debug is enabled, in delightful shade of magenta
 func Debug(s string) {
@@ -71,4 +80,17 @@ func (p Printfer) Printf(f string, a ...interface{}) {
 		return
 	}
 	fmt.Printf("\033[1;35m"+f+"\033[0m", a...)
+}
+
+// StartSpinner starts the spinner, which is disabled when debug is set
+func StartSpinner() {
+	if DebugEnabled {
+		return
+	}
+	consoleSpinner.Start()
+}
+
+// StopSpinner stops the spinner
+func StopSpinner() {
+	consoleSpinner.Stop()
 }

--- a/pkg/landingzone/action.go
+++ b/pkg/landingzone/action.go
@@ -8,7 +8,10 @@ package landingzone
 
 import (
 	"errors"
+	"fmt"
 	"strings"
+
+	"github.com/spf13/cobra"
 )
 
 type Action int
@@ -44,4 +47,8 @@ func NewAction(actionString string) (Action, error) {
 
 func (a Action) String() string {
 	return actionEnum[a]
+}
+
+func AddActionFlag(cmd *cobra.Command) {
+	cmd.Flags().StringP("action", "a", "init", fmt.Sprintf("Action to run, one of %v", actionEnum))
 }

--- a/pkg/landingzone/command.go
+++ b/pkg/landingzone/command.go
@@ -37,9 +37,9 @@ func SetSharedFlags(cmd *cobra.Command) {
 	AddActionFlag(cmd)
 	cmd.Flags().SortFlags = true
 
-	// Level command removed from launchpad cmd as it's always zero
+	// Level command not on launchpad cmd as we fix it to "level0"
 	if cmd.Parent().Name() != "launchpad" {
-		cmd.Flags().IntP("level", "l", 1, "Level")
+		cmd.Flags().StringP("level", "l", "level1", "Level")
 	}
 
 	_ = cobra.MarkFlagRequired(cmd.Flags(), "source")

--- a/pkg/landingzone/command.go
+++ b/pkg/landingzone/command.go
@@ -1,0 +1,41 @@
+package landingzone
+
+import (
+	"github.com/aztfmod/rover/pkg/console"
+	"github.com/spf13/cobra"
+)
+
+// RunFunc is the shared cobra run function for `landingzone run` and `launchpad run`
+func RunFunc(cmd *cobra.Command, args []string) {
+	actionStr, _ := cmd.Flags().GetString("action")
+	action, err := NewAction(actionStr)
+	cobra.CheckErr(err)
+	console.Infof("Starting '%s' command with action '%s'\n", cmd.CommandPath(), actionStr)
+
+	// Build config from command flags
+	opt := NewOptionsFromCmd(cmd)
+
+	ExecuteRun(opt, action)
+}
+
+// SetSharedFlags configures command flags for both landingzone and launchpad commands
+func SetSharedFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags()
+	cmd.Flags().StringP("source", "s", "", "Path to source of landingzone (required)")
+	cmd.Flags().StringP("config-path", "c", "", "Configuration vars directory (required)")
+	cmd.Flags().StringP("environment", "e", "sandpit", "Name of CAF environment")
+	cmd.Flags().StringP("workspace", "w", "tfstate", "Name of workspace")
+	cmd.Flags().StringP("statename", "n", "", "Name for state and plan files, (default landingzone source dir name)")
+	cmd.Flags().String("state-sub", "", "Azure subscription ID where state is held")
+	cmd.Flags().String("target-sub", "", "Azure subscription ID to operate on")
+	AddActionFlag(cmd)
+	cmd.Flags().SortFlags = true
+
+	// Level command removed from launchpad cmd as it's always zero
+	if cmd.Parent().Name() != "launchpad" {
+		cmd.Flags().IntP("level", "l", 1, "Level")
+	}
+
+	_ = cobra.MarkFlagRequired(cmd.Flags(), "source")
+	_ = cobra.MarkFlagRequired(cmd.Flags(), "config-path")
+}

--- a/pkg/landingzone/command.go
+++ b/pkg/landingzone/command.go
@@ -15,7 +15,7 @@ func RunFunc(cmd *cobra.Command, args []string) {
 	// Build config from command flags
 	opt := NewOptionsFromCmd(cmd)
 
-	ExecuteRun(opt, action)
+	opt.Execute(action)
 }
 
 // SetSharedFlags configures command flags for both landingzone and launchpad commands

--- a/pkg/landingzone/command.go
+++ b/pkg/landingzone/command.go
@@ -1,3 +1,9 @@
+//
+// Rover - support for landingzone / launchpad cobra cmds
+// * Curent status is: launchpad deploy works and sets up remote state
+// * Ben C, May 2021
+//
+
 package landingzone
 
 import (

--- a/pkg/landingzone/landingzone.go
+++ b/pkg/landingzone/landingzone.go
@@ -66,15 +66,15 @@ func (o Options) Execute(action Action) {
 		console.Infof("Located state storage account %s\n", existingStorageID)
 	}
 
+	// TODO: PUT COMMMANDS HERE THAT DONT NEED INIT AND EXIT EARLY
+
 	// Run init in correct mode
-	if action == ActionInit || action == ActionPlan || action == ActionDeploy {
-		if o.LaunchPadMode && existingStorageID == "" {
-			err = o.runLaunchpadInit(tf)
-		} else {
-			err = o.runRemoteInit(tf, existingStorageID)
-		}
-		cobra.CheckErr(err)
+	if o.LaunchPadMode && existingStorageID == "" {
+		err = o.runLaunchpadInit(tf)
+	} else {
+		err = o.runRemoteInit(tf, existingStorageID)
 	}
+	cobra.CheckErr(err)
 
 	// If the action is just init, then stop here and don't proceed
 	if action == ActionInit {

--- a/pkg/landingzone/landingzone.go
+++ b/pkg/landingzone/landingzone.go
@@ -23,6 +23,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const terraformParallelism = 30
+
 // Execute is entry point for `landingzone run`, `launchpad run` and `cd` operations
 // This executes an action against a set of config options
 func (o Options) Execute(action Action) {
@@ -91,6 +93,7 @@ func (o Options) Execute(action Action) {
 		planOptions := []tfexec.PlanOption{
 			tfexec.Out(planFile),
 			tfexec.Refresh(true),
+			tfexec.Parallelism(terraformParallelism),
 		}
 
 		// Then merge all tfvars found in config directory into -var-file options
@@ -123,6 +126,7 @@ func (o Options) Execute(action Action) {
 		applyOptions := []tfexec.ApplyOption{
 			tfexec.DirOrPlan(planFile),
 			tfexec.StateOut(stateFile),
+			tfexec.Parallelism(terraformParallelism),
 		}
 
 		// Now actually invoke Terraform apply
@@ -187,7 +191,7 @@ func (o Options) runRemoteInit(tf *tfexec.Terraform, storageID string) error {
 	return err
 }
 
-// All env vars and other steps need before running Terraform with CAF landingzones
+// This function
 func (o *Options) initializeCAF() *tfexec.Terraform {
 	tfPath, err := terraform.Setup()
 	cobra.CheckErr(err)

--- a/pkg/landingzone/landingzone.go
+++ b/pkg/landingzone/landingzone.go
@@ -24,19 +24,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// RunFunc is the shared cobra run function for `landingzone run` and `launchpad run`
-func RunFunc(cmd *cobra.Command, args []string) {
-	actionStr, _ := cmd.Flags().GetString("action")
-	action, err := NewAction(actionStr)
-	cobra.CheckErr(err)
-	console.Infof("Starting '%s' command with action '%s'\n", cmd.CommandPath(), actionStr)
-
-	// Build config from command flags
-	opt := NewOptionsFromCmd(cmd)
-
-	ExecuteRun(opt, action)
-}
-
 // ExecuteRun is entry point for `landingzone run`, `launchpad run` and `cd` commands
 // This executes a run operation on a option set
 // TODO: refactor Options into something like "RunOperation" then refactor this into having an RunOperation receiver
@@ -97,28 +84,6 @@ func ExecuteRun(opt Options, action Action) {
 	cobra.CheckErr(err)
 
 	console.Success("Rover completed")
-}
-
-// SetSharedFlags configures command flags for both landingzone and launchpad commands
-func SetSharedFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags()
-	cmd.Flags().StringP("source", "s", "", "Path to source of landingzone (required)")
-	cmd.Flags().StringP("config-path", "c", "", "Configuration vars directory (required)")
-	cmd.Flags().StringP("environment", "e", "sandpit", "Name of CAF environment")
-	cmd.Flags().StringP("workspace", "w", "tfstate", "Name of workspace")
-	cmd.Flags().StringP("statename", "n", "", "Name for state and plan files, (default landingzone source dir name)")
-	cmd.Flags().String("state-sub", "", "Azure subscription ID where state is held")
-	cmd.Flags().String("target-sub", "", "Azure subscription ID to operate on")
-	AddActionFlag(cmd)
-	cmd.Flags().SortFlags = true
-
-	// Level command removed from launchpad cmd as it's always zero
-	if cmd.Parent().Name() != "launchpad" {
-		cmd.Flags().IntP("level", "l", 1, "Level")
-	}
-
-	_ = cobra.MarkFlagRequired(cmd.Flags(), "source")
-	_ = cobra.MarkFlagRequired(cmd.Flags(), "config-path")
 }
 
 // Carry out the plan/deploy/destroy action

--- a/pkg/landingzone/landingzone.go
+++ b/pkg/landingzone/landingzone.go
@@ -1,5 +1,5 @@
 //
-// Rover - Core functions shared by landing zone & launchpad
+// Rover - Core execution of landingzone operations and actions
 // * Curent status is: launchpad deploy works and sets up remote state
 // * Ben C, May 2021
 //

--- a/pkg/landingzone/options.go
+++ b/pkg/landingzone/options.go
@@ -19,11 +19,12 @@ import (
 
 // Options holds all the settings for a langingzone or launchpad operation
 // It's populated first by calling NewOptionsFromCmd, then the RunCmd func sets Subscription & Identity fields
+// TODO: This probably needs a better name like `Operation` or something
 type Options struct {
 	LaunchPadMode      bool
 	ConfigPath         string
 	SourcePath         string
-	Level              int
+	Level              string
 	CafEnvironment     string
 	StateName          string
 	Workspace          string
@@ -31,7 +32,6 @@ type Options struct {
 	StateSubscription  string
 	Impersonate        bool
 	OutPath            string
-	RunInit            bool
 	Subscription       azure.Subscription
 	Identity           azure.Identity
 }
@@ -41,19 +41,21 @@ const cafLandingzoneDir = "/caf_solution"
 
 // NewOptionsFromCmd builds a Config from command flags
 func NewOptionsFromCmd(cmd *cobra.Command) Options {
-	launchPadMode := false
-	if cmd.Parent().Name() == "launchpad" {
-		launchPadMode = true
-	}
-
 	configPath, _ := cmd.Flags().GetString("config-path")
 	sourcePath, _ := cmd.Flags().GetString("source")
-	level, _ := cmd.Flags().GetInt("level")
+	level, _ := cmd.Flags().GetString("level")
 	env, _ := cmd.Flags().GetString("environment")
 	stateName, _ := cmd.Flags().GetString("statename")
 	ws, _ := cmd.Flags().GetString("workspace")
 	stateSub, _ := cmd.Flags().GetString("state-sub")
 	targetSub, _ := cmd.Flags().GetString("target-sub")
+
+	// Handle the launchpad mode special case
+	launchPadMode := false
+	if cmd.Parent().Name() == "launchpad" {
+		launchPadMode = true
+		level = "level0"
+	}
 
 	// This is a 'just in case' default, it will be changed later
 	outPath, err := os.UserHomeDir()
@@ -76,7 +78,6 @@ func NewOptionsFromCmd(cmd *cobra.Command) Options {
 		TargetSubscription: targetSub,
 		StateSubscription:  stateSub,
 		OutPath:            outPath,
-		RunInit:            true,
 	}
 
 	// Safely set the paths up
@@ -88,9 +89,9 @@ func NewOptionsFromCmd(cmd *cobra.Command) Options {
 
 // LevelString returns the level as formated string
 // This should be used rather than accessing level directly
-func (o Options) LevelString() string {
-	return fmt.Sprintf("level%d", o.Level)
-}
+// func (o Options) LevelString() string {
+// 	return fmt.Sprintf("level%d", o.Level)
+// }
 
 // SetSourcePath ensures the source path is correct and absolute
 func (o *Options) SetSourcePath(sourcePath string) {

--- a/pkg/landingzone/options.go
+++ b/pkg/landingzone/options.go
@@ -65,14 +65,7 @@ func NewOptionsFromCmd(cmd *cobra.Command) Options {
 	cobra.CheckErr(err)
 
 	// IMPORTANT: Append relevant caf directory to source, as required for the mode
-	if strings.HasSuffix(sourcePath, cafLaunchPadDir) || strings.HasSuffix(sourcePath, cafLandingzoneDir) {
-		cobra.CheckErr(fmt.Sprintf("source should not include %s or %s", cafLandingzoneDir, cafLaunchPadDir))
-	}
-	if launchPadMode {
-		sourcePath = path.Join(sourcePath, cafLaunchPadDir)
-	} else {
-		sourcePath = path.Join(sourcePath, cafLandingzoneDir)
-	}
+	sourcePath = SetSourceDir(sourcePath, launchPadMode)
 
 	// Default state & plan name is taken from the base name of the landingzone source dir
 	if stateName == "" {
@@ -102,4 +95,16 @@ func NewOptionsFromCmd(cmd *cobra.Command) Options {
 // This should be used rather than accessing level directly
 func (o Options) LevelString() string {
 	return fmt.Sprintf("level%d", o.Level)
+}
+
+func SetSourceDir(sourcePath string, launchPadMode bool) string {
+	if strings.HasSuffix(sourcePath, cafLaunchPadDir) || strings.HasSuffix(sourcePath, cafLandingzoneDir) {
+		cobra.CheckErr(fmt.Sprintf("source should not include %s or %s", cafLandingzoneDir, cafLaunchPadDir))
+	}
+	if launchPadMode {
+		sourcePath = path.Join(sourcePath, cafLaunchPadDir)
+	} else {
+		sourcePath = path.Join(sourcePath, cafLandingzoneDir)
+	}
+	return sourcePath
 }

--- a/pkg/landingzone/options.go
+++ b/pkg/landingzone/options.go
@@ -31,6 +31,7 @@ type Options struct {
 	StateSubscription  string
 	Impersonate        bool
 	OutPath            string
+	RunInit            bool
 	Subscription       azure.Subscription
 	Identity           azure.Identity
 }
@@ -75,6 +76,7 @@ func NewOptionsFromCmd(cmd *cobra.Command) Options {
 		TargetSubscription: targetSub,
 		StateSubscription:  stateSub,
 		OutPath:            outPath,
+		RunInit:            true,
 	}
 
 	// Safely set the paths up

--- a/pkg/landingzone/options.go
+++ b/pkg/landingzone/options.go
@@ -54,6 +54,7 @@ func NewOptionsFromCmd(cmd *cobra.Command) Options {
 	launchPadMode := false
 	if cmd.Parent().Name() == "launchpad" {
 		launchPadMode = true
+		// TODO: Maybe we have to remove this assumption and add --level flag to the `launchpad` cmd 😥
 		level = "level0"
 	}
 

--- a/pkg/symphony/cd.go
+++ b/pkg/symphony/cd.go
@@ -57,11 +57,12 @@ func (c Config) runStack(level Level, stack *Stack, action landingzone.Action) {
 		CafEnvironment: cafEnv,
 		StateName:      stack.Name,
 		Workspace:      ws,
+		RunInit:        true,
 	}
 	// Safely set the paths up
 	opt.SetSourcePath(sourcePath)
 	opt.SetConfigPath(configPath)
 
 	// Now we can start the execution just like `landingzone run` cmd does
-	landingzone.ExecuteRun(opt, action)
+	opt.Execute(action)
 }

--- a/pkg/symphony/cd.go
+++ b/pkg/symphony/cd.go
@@ -1,0 +1,68 @@
+package symphony
+
+import (
+	"path/filepath"
+
+	"github.com/aztfmod/rover/pkg/console"
+	"github.com/aztfmod/rover/pkg/landingzone"
+	"github.com/spf13/cobra"
+)
+
+func (c Config) RunAll(action landingzone.Action) {
+	console.Infof("Starting CD process for all levels...\n")
+
+	for _, level := range c.Levels {
+		c.RunLevel(level, action)
+	}
+}
+
+func (c Config) RunLevel(level Level, action landingzone.Action) {
+	console.Infof(" - Running CD for level %d\n", level.Number)
+	for _, stack := range level.Stacks {
+		c.runStack(level, &stack, action)
+	}
+}
+
+func (c Config) runStack(level Level, stack *Stack, action landingzone.Action) {
+	console.Infof("   - Running CD for stack %s\n", stack.Name)
+
+	ws := c.Workspace
+	if ws == "" {
+		ws = "tfstate"
+	}
+
+	cafEnv := c.Environment
+	if cafEnv == "" {
+		cafEnv = "sandpit"
+	}
+
+	lzPath := c.LandingZonePath
+	if lzPath == "" {
+		cobra.CheckErr("Config file is missing 'landingZonePath' setting")
+	}
+
+	// Convert to absolute paths as a precaution
+	lzPath, err := filepath.Abs(lzPath)
+	cobra.CheckErr(err)
+	lzPath = landingzone.SetSourceDir(lzPath, level.Launchpad)
+	configPath, err := filepath.Abs(stack.ConfigurationPath)
+	cobra.CheckErr(err)
+
+	// TODO: Remove this safe guard when landingzone deploy is working
+	if !level.Launchpad {
+		console.Error("landingzone deployment is not implemented yet")
+		return
+	}
+
+	opt := landingzone.Options{
+		Level:          level.Number,
+		ConfigPath:     configPath,
+		SourcePath:     lzPath,
+		LaunchPadMode:  level.Launchpad,
+		CafEnvironment: cafEnv,
+		StateName:      stack.Name,
+		Workspace:      ws,
+	}
+
+	landingzone.ExecuteRun(opt, action)
+}

--- a/pkg/symphony/cd.go
+++ b/pkg/symphony/cd.go
@@ -15,7 +15,7 @@ func (c Config) RunAll(action landingzone.Action) {
 }
 
 func (c Config) RunLevel(level Level, action landingzone.Action) {
-	console.Infof(" - Running CD for level %d\n", level.Number)
+	console.Infof(" - Running CD for level: %s\n", level.Name)
 	for _, stack := range level.Stacks {
 		c.runStack(level, &stack, action)
 	}
@@ -24,7 +24,7 @@ func (c Config) RunLevel(level Level, action landingzone.Action) {
 // This runs the given action against the stack
 // It builds a landingzone.Options struct just like landingzone.NewOptionsFromCmd() but uses the YAML as source not the cmd
 func (c Config) runStack(level Level, stack *Stack, action landingzone.Action) {
-	console.Infof("   - Running CD for stack %s\n", stack.Name)
+	console.Infof("   - Running CD for stack: %s\n", stack.Name)
 
 	ws := c.Workspace
 	if ws == "" {
@@ -52,12 +52,11 @@ func (c Config) runStack(level Level, stack *Stack, action landingzone.Action) {
 	}
 
 	opt := landingzone.Options{
-		Level:          level.Number,
+		Level:          level.Name,
 		LaunchPadMode:  level.Launchpad,
 		CafEnvironment: cafEnv,
 		StateName:      stack.Name,
 		Workspace:      ws,
-		RunInit:        true,
 	}
 	// Safely set the paths up
 	opt.SetSourcePath(sourcePath)

--- a/pkg/symphony/cd.go
+++ b/pkg/symphony/cd.go
@@ -51,13 +51,20 @@ func (c Config) runStack(level Level, stack *Stack, action landingzone.Action) {
 		return
 	}
 
+	stateName := stack.TfState
+	// IMPORTANT: We use the stack name as the default name if tfState key is not supplied
+	if stateName == "" {
+		stateName = stack.Name
+	}
+
 	opt := landingzone.Options{
 		Level:          level.Name,
 		LaunchPadMode:  level.Launchpad,
 		CafEnvironment: cafEnv,
-		StateName:      stack.Name,
+		StateName:      stateName,
 		Workspace:      ws,
 	}
+
 	// Safely set the paths up
 	opt.SetSourcePath(sourcePath)
 	opt.SetConfigPath(configPath)

--- a/pkg/symphony/symphony.go
+++ b/pkg/symphony/symphony.go
@@ -1,6 +1,7 @@
 package symphony
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -9,29 +10,39 @@ import (
 )
 
 type Config struct {
-	Environment  string `yaml:"environment,omitempty"`
-	Repositories []struct {
+	Version         int    `yaml:"symphonyVersion,omitempty"`
+	Environment     string `yaml:"environment,omitempty"`
+	LandingZonePath string `yaml:"landingZonePath,omitempty"`
+	Workspace       string
+	Repositories    []struct {
 		Name   string `yaml:"name,omitempty"`
 		URI    string `yaml:"uri,omitempty"`
 		Branch string `yaml:"branch,omitempty"`
 	}
-	Levels []struct {
-		Level     string `yaml:"level,omitempty"`
-		Type      string `yaml:"type,omitempty"`
-		Launchpad bool   `yaml:"launchpad,omitempty"`
-		Stacks    []struct {
-			Stack             string `yaml:"stack,omitempty"`
-			LandingZonePath   string `yaml:"landingZonePath,omitempty"`
-			ConfigurationPath string `yaml:"configurationPath,omitempty"`
-			TfState           string `yaml:"tfState,omitempty"`
-		}
-	}
+	Levels []Level
+}
+
+type Level struct {
+	Number    int    `yaml:"level,omitempty"`
+	Type      string `yaml:"type,omitempty"`
+	Launchpad bool   `yaml:"launchpad,omitempty"`
+	Stacks    []Stack
+}
+
+type Stack struct {
+	Name              string `yaml:"stack,omitempty"`
+	LandingZonePath   string `yaml:"landingZonePath,omitempty"`
+	ConfigurationPath string `yaml:"configurationPath,omitempty"`
+	TfState           string `yaml:"tfState,omitempty"`
 }
 
 func NewSymphonyConfig(symphonyConfigFileName string) (*Config, error) {
 	sc := new(Config)
 	buf, _ := os.ReadFile(symphonyConfigFileName)
 	err := yaml.Unmarshal(buf, sc)
+	if sc.Version != 2 {
+		return nil, errors.New("Bad symphony version number, this version of rover requires version 2")
+	}
 
 	return sc, err
 }

--- a/pkg/symphony/symphony.go
+++ b/pkg/symphony/symphony.go
@@ -23,7 +23,7 @@ type Config struct {
 }
 
 type Level struct {
-	Number    int    `yaml:"level,omitempty"`
+	Name      string `yaml:"level,omitempty"`
 	Type      string `yaml:"type,omitempty"`
 	Launchpad bool   `yaml:"launchpad,omitempty"`
 	Stacks    []Stack

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,10 @@
+//
+// Rover - Version
+// * An entire package for this?! It fixes a circular dependency problem which haunted me for days...
+// * Ben C, May 2021
+//
+
+package version
+
+// Value is the version of rover
+var Value = "0.0.0"


### PR DESCRIPTION
This is another mother of all PRs :( With many changes
- cmd/cd.go handles the run sub command and parses input symphony yaml
  - Able to run against all levels or just single level
  - Each stack inside the level is processed
- symphony/cd.go contains the implementation code for running actions against levels, all levels and stages
- symphony/symphony.go required some changes to expose inner struct types
- MANY changes to the existing v1 symphony format, see #36
- Factored version to it's own package to solve circular import issue
- Simplified code flow in landingzone.go so that Execute is the main function handling all actions
- Adds `RunInit: bool` to `Options` to allow actions to skip running the init stage

Fixes #30