### PR TITLE
Implement destroy action for launchpad

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,6 +21,22 @@
       ]
     },
     {
+      "name": "Debug CD CLI",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}",
+      "args": [
+        "cd",
+        "--level",
+        "level0",
+        "-c",
+        "./local/symphony.yaml",
+        "-a",
+        "init"
+      ]
+    },
+    {
       "name": "Debug Root",
       "type": "go",
       "request": "launch",

--- a/cmd/launchpad_run.go
+++ b/cmd/launchpad_run.go
@@ -1,5 +1,5 @@
 //
-// Rover - Landing zone run command is the core of rover
+// Rover - Launchpad run command
 // * This carries out actions like plan, apply or destroy via terrafrom
 // * TODO: Work in progress
 // * Ben C, May 2021

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-VERSION ?= 2.0.1
+VERSION ?= 0.0.1
 
 .PHONY: build help lint lint-fix run test clean
 .DEFAULT_GOAL := help

--- a/pkg/landingzone/landingzone.go
+++ b/pkg/landingzone/landingzone.go
@@ -245,7 +245,7 @@ func (o *Options) Execute(action Action) {
 }
 
 // Carry out Terraform init operation in launchpad mode has no backend state
-func (o *Options) runLaunchpadInit(tf *tfexec.Terraform) error {
+func (o *Options) runLaunchpadInit(tf *tfexec.Terraform, reconfigure bool) error {
 	console.Info("Running init for launchpad")
 
 	console.StartSpinner()

--- a/pkg/landingzone/landingzone.go
+++ b/pkg/landingzone/landingzone.go
@@ -27,7 +27,7 @@ const terraformParallelism = 30
 
 // Execute is entry point for `landingzone run`, `launchpad run` and `cd` operations
 // This executes an action against a set of config options
-func (o Options) Execute(action Action) {
+func (o *Options) Execute(action Action) {
 	// Get current Azure details, subscription etc from CLI
 	acct := azure.GetSubscription()
 	ident := azure.GetIdentity()
@@ -47,17 +47,17 @@ func (o Options) Execute(action Action) {
 		}
 	}
 
-	// Remove old files, reset backend etc
-	o.cleanUp()
-
 	// All the env vars & other setup needed for CAF and get handle on Terraform
 	tf := o.initializeCAF()
+
+	// Remove old files, reset backend etc
+	o.cleanUp()
 
 	// Find state storage account for this environment and level
 	existingStorageID, err := azure.FindStorageAccount(o.Level, o.CafEnvironment, o.StateSubscription)
 	if err != nil {
 		if o.LaunchPadMode {
-			console.Warning("No state storage account found, but running in launchpad mode, it will be created")
+			console.Warning("No state storage account found, but running in launchpad mode, we can continue")
 		} else {
 			console.Errorf("No state storage account found for environment '%s' and level %d, please deploy a launchpad first!\n", o.CafEnvironment, o.Level)
 			cobra.CheckErr("Can't deploy a landing zone without a launchpad")
@@ -70,7 +70,7 @@ func (o Options) Execute(action Action) {
 
 	// Run init in correct mode
 	if o.LaunchPadMode && existingStorageID == "" {
-		err = o.runLaunchpadInit(tf)
+		err = o.runLaunchpadInit(tf, false)
 	} else {
 		err = o.runRemoteInit(tf, existingStorageID)
 	}
@@ -84,7 +84,9 @@ func (o Options) Execute(action Action) {
 
 	console.Infof("Starting '%s' action, this could take some time...\n", action.String())
 
-	// Plan is run for both plan and deploy actions
+	//
+	// Plan action
+	//
 	if action == ActionPlan || action == ActionDeploy {
 		console.Info("Carrying out the Terraform plan phase")
 
@@ -99,7 +101,10 @@ func (o Options) Execute(action Action) {
 		// Then merge all tfvars found in config directory into -var-file options
 		varOpts, err := terraform.ExpandVarDirectory(o.ConfigPath)
 		cobra.CheckErr(err)
-		planOptions = append(planOptions, varOpts...)
+		for _, vo := range varOpts {
+			// Note. spread operator would not work here, I tried ¯\_(ツ)_/¯
+			planOptions = append(planOptions, vo)
+		}
 
 		// Now actually invoke Terraform plan
 		console.StartSpinner()
@@ -116,6 +121,9 @@ func (o Options) Execute(action Action) {
 		}
 	}
 
+	//
+	// Deploy action
+	//
 	if action == ActionDeploy {
 		console.Info("Carrying out the Terraform apply phase")
 
@@ -150,15 +158,77 @@ func (o Options) Execute(action Action) {
 		console.Success("Apply was successful")
 	}
 
+	//
+	// Destroy action
+	//
+	if action == ActionDestroy {
+		console.Info("Carrying out the Terraform destroy phase")
+
+		stateFileName := o.OutPath + "/" + o.StateName + ".tfstate"
+
+		// Build apply options, with plan file and state out
+		destroyOptions := []tfexec.DestroyOption{
+			tfexec.Parallelism(terraformParallelism),
+			tfexec.Refresh(false),
+		}
+
+		// We need to do all sorts of extra shenanigans for launchPadMode
+		if o.LaunchPadMode {
+			console.Warning("WARNING! You are destroying the launchpad!")
+			if existingStorageID == "" {
+				console.Error("Looks like this launchpad has already been deleted, bye!")
+				cobra.CheckErr("Destroy was aborted")
+			}
+
+			// IMPORTANT!
+			o.cleanUp()
+
+			// Download the current state
+			azure.DownloadFileFromBlob(existingStorageID, o.Workspace, o.StateName+".tfstate", stateFileName)
+
+			// Reset back to use local state
+			console.Warning("Resetting state to local, have to re-run init")
+			err = o.runLaunchpadInit(tf, true)
+			cobra.CheckErr(err)
+			// IMPORTANT!
+			_ = os.Remove(o.SourcePath + "/backend.azurerm.tf")
+
+			// Tell destroy to use local downloaded state to destroy a launchpad
+			// TODO: This is a deprecated option, the solution is to switch to this
+			// https://www.terraform.io/docs/language/settings/backends/local.html
+			// nolint
+			destroyOptions = append(destroyOptions, tfexec.State(stateFileName))
+		}
+
+		// Merge all tfvars found in config directory into -var-file options
+		varOpts, err := terraform.ExpandVarDirectory(o.ConfigPath)
+		cobra.CheckErr(err)
+		for _, vo := range varOpts {
+			// Note. spread operator would not work here, I tried ¯\_(ツ)_/¯
+			destroyOptions = append(destroyOptions, vo)
+		}
+
+		// Now actually invoke Terraform apply
+		console.Warning("Destroy is now running ...")
+		console.StartSpinner()
+		err = tf.Destroy(context.Background(), destroyOptions...)
+		console.StopSpinner()
+		cobra.CheckErr(err)
+
+		// Remove files
+		o.cleanUp()
+		_ = os.RemoveAll(o.OutPath)
+		console.Success("Destroy was successful")
+	}
 	console.Success("Rover completed")
 }
 
 // Carry out Terraform init operation in launchpad mode has no backend state
-func (o Options) runLaunchpadInit(tf *tfexec.Terraform) error {
+func (o Options) runLaunchpadInit(tf *tfexec.Terraform, reconfigure bool) error {
 	console.Info("Running init for launchpad")
 
 	console.StartSpinner()
-	err := tf.Init(context.Background(), tfexec.Upgrade(true))
+	err := tf.Init(context.Background(), tfexec.Upgrade(true), tfexec.Reconfigure(reconfigure))
 	console.StopSpinner()
 	return err
 }
@@ -267,7 +337,7 @@ func (o Options) cleanUp() {
 	_ = os.Remove(os.Getenv("TF_DATA_DIR") + "/terraform.tfstate")
 }
 
-// By copying this file we enable teh azurerm backend and therefore remote state
+// By copying this file we enable the azurerm backend and therefore remote state
 func (o Options) enableAzureBackend() {
 	console.Info("Enabling backend state with backend.azurerm.tf file")
 	err := utils.CopyFile(o.SourcePath+"/backend.azurerm", o.SourcePath+"/backend.azurerm.tf")

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -70,9 +70,9 @@ func CheckVersion(path string) {
 	console.Successf("Terraform is at version %v\n", tfVer)
 }
 
-// ExpandVarDirectory returns an array of plan options from a directory of tfvars
-func ExpandVarDirectory(varDir string) ([]tfexec.PlanOption, error) {
-	planOptions := []tfexec.PlanOption{}
+// ExpandVarDirectory returns an array of var file options from a directory of tfvars
+func ExpandVarDirectory(varDir string) ([]*tfexec.VarFileOption, error) {
+	varFileOpts := []*tfexec.VarFileOption{}
 
 	// Finds all .tfvars in directory and recurse down
 	err := filepath.Walk(varDir, func(path string, info os.FileInfo, err error) error {
@@ -80,7 +80,8 @@ func ExpandVarDirectory(varDir string) ([]tfexec.PlanOption, error) {
 			return nil
 		}
 
-		planOptions = append(planOptions, tfexec.VarFile(path))
+		varFileOpt := tfexec.VarFile(path)
+		varFileOpts = append(varFileOpts, varFileOpt)
 		console.Debugf("Found var file to use: %s\n", path)
 		return nil
 	})
@@ -89,5 +90,5 @@ func ExpandVarDirectory(varDir string) ([]tfexec.PlanOption, error) {
 		return nil, err
 	}
 
-	return planOptions, nil
+	return varFileOpts, nil
 }


### PR DESCRIPTION
- ✨ FEAT: destroy action works for cd + symphony and standalone lp command 
- 🐞 BUGFIX: Changed the main Execute function to receive a pointer to Options
- 🐞 BUGFIX: the order of calls to cleanUp and initializeCAF were swapped
- 🍕 ADDS: DownloadFileFromBlob function in azure/storage.go

Fixes #37