### PR TITLE
ci_tasks required even when commands is not ci

### DIFF
--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -70,7 +70,7 @@ func addCITasks(cmd *cobra.Command) {
 						taskConfig.OutputDebug()
 					}
 
-				symphonyConfig.RunCITask(directoryName, subCommandName, level, debug)
+					symphonyConfig.RunCITask(directoryName, subCommandName, level, debug)
 
 				},
 			}


### PR DESCRIPTION
Fixes #52
Tests for folder existance. If not found bypasses ci subcommand creation, displays warning message:
CI command disabled, required ci task directory not found: <directory from config>

Can test with and without ci-task directory using:

go run main.go ci -h
