### PR TITLE
Implement plan/apply/destroy for landingzones

### DIFF
--- a/cmd/cd.go
+++ b/cmd/cd.go
@@ -9,6 +9,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/aztfmod/rover/pkg/console"
 	"github.com/aztfmod/rover/pkg/landingzone"
 	"github.com/aztfmod/rover/pkg/symphony"
 	"github.com/spf13/cobra"
@@ -54,6 +55,7 @@ func init() {
 
 				if levelFlag == "" {
 					conf.RunAll(action)
+					console.Success("Rover has finished")
 					return
 				}
 
@@ -72,6 +74,7 @@ func init() {
 				}
 				//nolint
 				conf.RunLevel(*level, action)
+				console.Success("Rover has finished")
 			},
 		}
 

--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -10,6 +10,7 @@ package cmd
 import (
 	"path/filepath"
 
+	"github.com/aztfmod/rover/pkg/console"
 	"github.com/aztfmod/rover/pkg/symphony"
 	"github.com/spf13/cobra"
 )
@@ -70,6 +71,7 @@ func addCITasks(cmd *cobra.Command) {
 				// runCITaskSubCommand(directoryName, subCommandName, symphonyConfig, level, debug)
 				symphonyConfig.RunCITask(directoryName, subCommandName, level, debug)
 
+				console.Success("Rover has finished")
 			},
 		}
 

--- a/cmd/landingzone.go
+++ b/cmd/landingzone.go
@@ -7,6 +7,7 @@
 package cmd
 
 import (
+	"github.com/aztfmod/rover/pkg/console"
 	"github.com/aztfmod/rover/pkg/landingzone"
 	"github.com/spf13/cobra"
 )
@@ -34,6 +35,8 @@ func init() {
 				opt := landingzone.NewOptionsFromCmd(cmd)
 				// And execute the relevant action
 				opt.Execute(action)
+
+				console.Success("Rover has finished")
 			},
 		}
 		// Set all the shared action flags

--- a/cmd/launchpad.go
+++ b/cmd/launchpad.go
@@ -7,6 +7,7 @@
 package cmd
 
 import (
+	"github.com/aztfmod/rover/pkg/console"
 	"github.com/aztfmod/rover/pkg/landingzone"
 	"github.com/spf13/cobra"
 )
@@ -33,6 +34,8 @@ func init() {
 				opt := landingzone.NewOptionsFromCmd(cmd)
 				// And execute the relevant action
 				opt.Execute(action)
+
+				console.Success("Rover has finished")
 			},
 		}
 		// Set all the shared action flags

--- a/pkg/landingzone/landingzone.go
+++ b/pkg/landingzone/landingzone.go
@@ -396,7 +396,7 @@ func (o *Options) enableAzureBackend() {
 }
 
 // Sets various TF_VAR_ variables required for a landingzone to be deployed/destroyed
-func (o *Options) connectToLaunchPad(lpStorageId string) error {
+func (o *Options) connectToLaunchPad(lpStorageID string) error {
 	console.Infof("Connecting to launchpad for level '%s'\n", o.Level)
 	lpKeyVaultID, err := azure.FindKeyVault(o.Level, o.CafEnvironment, o.StateSubscription)
 	if err != nil {
@@ -431,7 +431,7 @@ func (o *Options) connectToLaunchPad(lpStorageId string) error {
 		return fmt.Errorf("Required secret(s) not found in launchpad, either you are not authorized ot the launchpad was not deployed correctly")
 	}
 
-	_, lpStorageResGrp, lpStorageName := azure.ParseResourceID(lpStorageId)
+	_, lpStorageResGrp, lpStorageName := azure.ParseResourceID(lpStorageID)
 
 	console.Success("Connected to launchpad OK")
 	console.Debugf(" - TF_VAR_tenant_id=%s\n", lpTenantID)

--- a/pkg/symphony/cd.go
+++ b/pkg/symphony/cd.go
@@ -46,10 +46,10 @@ func (c Config) runStack(level Level, stack *Stack, action landingzone.Action) {
 	}
 
 	// TODO: Remove this safe guard when landingzone deploy is working
-	if !level.Launchpad {
-		console.Error("landingzone deployment is not implemented yet")
-		return
-	}
+	// if !level.Launchpad {
+	// 	console.Error("landingzone deployment is not implemented yet")
+	// 	return
+	// }
 
 	stateName := stack.TfState
 	// IMPORTANT: We use the stack name as the default name if tfState key is not supplied
@@ -71,4 +71,5 @@ func (c Config) runStack(level Level, stack *Stack, action landingzone.Action) {
 
 	// Now we can start the execution just like `landingzone run` cmd does
 	opt.Execute(action)
+	console.Successf("Finished execution on stack '%s'\n", stack.Name)
 }

--- a/readme.md
+++ b/readme.md
@@ -9,14 +9,14 @@ This is a breaking change from the previous version with large scale changes.
 # Current Status
 
 ### [👷‍♂️ Project board](https://github.com/orgs/aztfmod/projects/28?card_filter_query=label%3Arover-go)
-### ☢ This is under heavy development, expect braking changes almost daily 🔥
+### ☢ This is under heavy development, expect breaking changes almost daily 🔥
 
 ## Implemented 
 
 - `launchpad` - To deploy a launchpad
   - Actions init, plan, apply, destroy, fmt & validate implemented and working
   - Handling of state initialization and upload
-  - Handling of destorying a launchpad
+  - Handling of destroying a launchpad
 - `landingzone` - To deploy a landingzone
   - Actions init, plan, apply, destroy, fmt & validate implemented and working
   - Handling of state and connecting to launchpad

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,8 @@ A project to undertake re-writing the [Rover tool](https://github.com/aztfmod/ro
 
 Uses [Cobra](https://github.com/spf13/cobra) to provide the framework for a robust and familiar CLI tool and [Viper](https://github.com/spf13/viper) for configuration
 
+This is a breaking change from the previous version with large scale changes.
+
 # Current Status
 
 ### [👷‍♂️ Project board](https://github.com/orgs/aztfmod/projects/28?card_filter_query=label%3Arover-go)
@@ -11,22 +13,24 @@ Uses [Cobra](https://github.com/spf13/cobra) to provide the framework for a robu
 
 ## Implemented 
 
-- Shape of commands & sub-commands and CLI structure
 - `launchpad` - To deploy a launchpad
   - Actions init, plan, apply, destroy, fmt & validate implemented and working
   - Handling of state initialization and upload
-  - Handling of locating remote state from level and CAF environment
   - Handling of destorying a launchpad
 - `landingzone` - To deploy a landingzone
   - Actions init, plan, apply, destroy, fmt & validate implemented and working
   - Handling of state and connecting to launchpad
 - `landingzone fetch` - Implements the existing `--clone` option
-- `cd` - To run actions against multiple levels based on symphony config
+- `cd` - To run actions against single or multiple levels based on symphony config
 - `ci <task>` - To run any tasks defined in the ci_tasks directory, which are dynamically discovered
+- Supported actions for all `launchpad`, `landingzone`, `cd` are:
+  - `init`, `plan`, `apply`, `destroy`, `fmt`, `validate`, 
+- Shape of commands & sub-commands and CLI structure defined.
+- Handling of locating remote state from level and CAF environment .
 - Config file support, currently `.rover.yaml` is used and looked for in $HOME or cwd
 - Calling Azure APIs to make calls e.g. query resources with ARG, get storage account, upload blobs, get KV secrets
 - Interaction with Azure CLI to obtain subscription and current identity details
-- Goreleaser, GitHub Actions, linting, makefile
+- Fundamentals: Goreleaser, GitHub Actions (for CI and release), linting, makefile
 
 ### [📝 See the wiki for further details](https://github.com/aztfmod/rovergo/wiki)
 
@@ -36,6 +40,7 @@ In very rough order of priority
 
 - Testing with managed identity (system and user)
 - Testing with state and deployment in different subscriptions
+- Testing using other Azure clouds other than public
 - User impersonation
 - Terraform Cloud support
 - Landingzone list

--- a/readme.md
+++ b/readme.md
@@ -12,75 +12,30 @@ Uses [Cobra](https://github.com/spf13/cobra) to provide the framework for a robu
 ## Implemented 
 
 - Shape of commands & sub-commands and CLI structure
-- `launchpad fetch` - Implements the existing `--clone` option
-- `launchpad run` - To deploy a launchpad
-  - Actions init, plan, deploy & destroy implemented and working
+- `launchpad` - To deploy a launchpad
+  - Actions init, plan, apply, destroy, fmt & validate implemented and working
   - Handling of state initialization and upload
   - Handling of locating remote state from level and CAF environment
-- `cd run` - To run actions against multiple levels based on symphony config (only level0 currently)
+  - Handling of destorying a launchpad
+- `landingzone` - To deploy a landingzone
+  - Actions init, plan, apply, destroy, fmt & validate implemented and working
+  - Handling of state and connecting to launchpad
+- `landingzone fetch` - Implements the existing `--clone` option
+- `cd` - To run actions against multiple levels based on symphony config
 - `ci <task>` - To run any tasks defined in the ci_tasks directory, which are dynamically discovered
 - Config file support, currently `.rover.yaml` is used and looked for in $HOME or cwd
-- Calling Azure APIs to make calls e.g. query resources with ARG, get storage account, upload blobs
+- Calling Azure APIs to make calls e.g. query resources with ARG, get storage account, upload blobs, get KV secrets
 - Interaction with Azure CLI to obtain subscription and current identity details
 - Goreleaser, GitHub Actions, linting, makefile
 
 ### [📝 See the wiki for further details](https://github.com/aztfmod/rovergo/wiki)
 
-```text
-$ rover
-Azure CAF rover is a command line tool in charge of the deployment of the landing zones in your 
-Azure environment.
-It acts as a toolchain development environment to avoid impacting the local machine but more importantly 
-to make sure that all contributors in the GitOps teams are using a consistent set of tools and version.
-
-Usage:
-  rover [command]
-
-Available Commands:
-  cd          Manage CD operations.
-  ci          Manage CI operations.
-  help        Help about any command
-  landingzone Manage and deploy landing zones
-  launchpad   Manage and deploy launchpad, i.e. landing zone level0.
-  terraform   Manage terraform operations.
-  workspace   Manage workspace operations.
-
-Flags:
-      --config string   config file (default is ./.rover.yaml)
-      --debug           log extra debug information, may contain secrets
-  -h, --help            help for rover
-  -v, --version         version for rover
-
-Use "rover [command] --help" for more information about a command.
-```
-
-The flags on the launchpad / landingzone are as follows:
-
-```text
-Run actions to deploy, update or remove launchpads
-
-Usage:
-  rover launchpad run [flags]
-
-Flags:
-  -a, --action string        Action to run, one of [init | plan | deploy | destroy] (default "init")
-  -c, --config-path string   Configuration vars directory (required)
-  -e, --environment string   Name of CAF environment (default "sandpit")
-  -h, --help                 help for run
-  -s, --source string        Path to source of landingzone (required)
-      --state-sub string     Azure subscription ID where state is held
-  -n, --statename string     Name for state and plan files, defaults to landingzone name
-      --target-sub string    Azure subscription ID to operate on
-  -w, --workspace string     Name of workspace (default "tfstate")
-```
 # Major Outstanding Work
 
 In very rough order of priority
 
-- Rest of launchpad and landing zone operations - priority #1 ☺
-- Other remote state cases, e.g. login_as_launchpad
 - Testing with managed identity (system and user)
+- Testing with state and deployment in different subscriptions
 - User impersonation
-- CI operations
-- CD operations
 - Terraform Cloud support
+- Landingzone list


### PR DESCRIPTION
This is a small but very important PR it enables `landingzone` and `cd` operations for levels 1+. This means that plan/apply/destroy actions can now function on landingzone levels 1+ 

e.g. all of the following will now work....
* `cd apply --symphony-config local/symphony.yaml --level level1`
* `cd apply --symphony-config local/symphony.yaml`  (all levels)
* `cd destroy --symphony-config local/symphony.yaml --level level1`
* `landingzone apply --config-path ./local/configs/level1/web --source ./landingzones --statename web`

The key part making this happen is the function `connectToLaunchPad()` which sets many `TF_VAR_` variables based on the values extracted from the KeyVault located in the launchpad

The bulk of the important changes are in this commit
https://github.com/aztfmod/rovergo/pull/60/commits/265e30c347461b4eba81c0f55cab05e30528f3b5 

Fixes #60  
Fixes #21  