### PR TITLE
Checks & validation for source and config paths

### DIFF
--- a/pkg/landingzone/options.go
+++ b/pkg/landingzone/options.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/aztfmod/rover/pkg/azure"
+	"github.com/aztfmod/rover/pkg/console"
 	"github.com/spf13/cobra"
 )
 
@@ -100,8 +101,6 @@ func (o *Options) SetSourcePath(sourcePath string) {
 		cobra.CheckErr(fmt.Sprintf("source should not include %s or %s", cafLandingzoneDir, cafLaunchPadDir))
 	}
 
-	// TODO: Add validation that path exists and contains some .tf files
-
 	// Convert to absolute paths as a precaution
 	sourcePath, err := filepath.Abs(sourcePath)
 	cobra.CheckErr(err)
@@ -111,12 +110,36 @@ func (o *Options) SetSourcePath(sourcePath string) {
 	} else {
 		o.SourcePath = path.Join(sourcePath, cafLandingzoneDir)
 	}
+
+	// Try to ensure sourcepath is "good", i.e. exists & has some some terraform in it
+	_, err = os.Stat(o.SourcePath)
+	if err != nil {
+		console.Errorf("Unable to open source directory: %s\n", o.SourcePath)
+		cobra.CheckErr("Source directory must exist for rover to run")
+	}
+	foundTfFiles := false
+	sourceFiles, err := os.ReadDir(o.SourcePath)
+	cobra.CheckErr(err)
+	for _, file := range sourceFiles {
+		if strings.HasSuffix(file.Name(), ".tf") {
+			foundTfFiles = true
+			break
+		}
+	}
+	if !foundTfFiles {
+		console.Errorf("No terraform was found in source directory: %s\n", o.SourcePath)
+		cobra.CheckErr("Rover execution has ended")
+	}
 }
 
 func (o *Options) SetConfigPath(configPath string) {
-	// TODO: Add validation that path exists and contains some .tfvar files
-
 	configPath, err := filepath.Abs(configPath)
 	cobra.CheckErr(err)
 	o.ConfigPath = configPath
+
+	_, err = os.Stat(o.ConfigPath)
+	if err != nil {
+		console.Errorf("Unable to open config directory: %s\n", o.ConfigPath)
+		cobra.CheckErr("Config directory must exist for rover to run")
+	}
 }


### PR DESCRIPTION
- Checks the supplied source path exists and contains .tf files
- Checks the supplied config path exists and containers .tfvar files

In both cases rover execution is halted if they are not found to be ok
Fixes #70