### PR TITLE
Add startup checks for `az` and `terraform`

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,5 +1,6 @@
 //
 // Rover - main entry point
+// * Checks for dependent executables then
 // * Simply enters into the cobra root command and passes version
 // * Ben C, May 2021
 //
@@ -8,8 +9,10 @@ package main
 
 import (
 	"github.com/aztfmod/rover/cmd"
+	"github.com/aztfmod/rover/pkg/command"
 )
 
 func main() {
+	command.ValidateDependencies()
 	cmd.Execute()
 }

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -120,3 +120,19 @@ func CheckCommand(reqCmdName string) error {
 	}
 	return nil
 }
+
+func ValidateDependencies() {
+	azErr := CheckCommand("az")
+	if azErr != nil {
+		console.Errorf("The %s.\nPlease install from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli", azErr.Error())
+	}
+
+	tfErr := CheckCommand("terraform")
+	if tfErr != nil {
+		console.Errorf("The %s.\nPlease install from https://www.terraform.io/downloads.html \n", tfErr.Error())
+	}
+
+	if azErr != nil || tfErr != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Fixes #82
Added to main and command files. Not utils due to cyclic import with command.
Tested by renaming terraform executable.