### PR TITLE
Reduce reliance on Azure CLI 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aztfmod/rover
 go 1.16
 
 require (
-	github.com/Azure/azure-sdk-for-go v51.2.0+incompatible
+	github.com/Azure/azure-sdk-for-go v55.3.0+incompatible
 	github.com/Azure/azure-storage-blob-go v0.13.0
 	github.com/Azure/go-autorest/autorest v0.11.18
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.7
@@ -11,6 +11,7 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/briandowns/spinner v1.13.0
+	github.com/davecgh/go-spew v1.1.1
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-exec v0.13.3
 	github.com/spf13/cobra v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-pipeline-go v0.2.3 h1:7U9HBg1JFK3jHl5qmo4CTZKFTVgMwdFHMVtCdfBE21U=
 github.com/Azure/azure-pipeline-go v0.2.3/go.mod h1:x841ezTBIMG6O3lAcl8ATHnsOPVl2bqk7S3ta6S6u4k=
-github.com/Azure/azure-sdk-for-go v51.2.0+incompatible h1:qQNk//OOHK0GZcgMMgdJ4tZuuh0zcOeUkpTxjvKFpSQ=
-github.com/Azure/azure-sdk-for-go v51.2.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v55.3.0+incompatible h1:rLKCdFMMCAXt/QZ96skZJUArYS3UDo9Qm1ZWzoDtC9E=
+github.com/Azure/azure-sdk-for-go v55.3.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-storage-blob-go v0.13.0 h1:lgWHvFh+UYBNVQLFHXkvul2f6yOPA9PIH82RTG2cSwc=
 github.com/Azure/azure-storage-blob-go v0.13.0/go.mod h1:pA9kNqtjUeQF2zOSu4s//nUdBD+e64lEuc4sVnuOfNs=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=

--- a/pkg/azure/auth.go
+++ b/pkg/azure/auth.go
@@ -32,11 +32,11 @@ func GetAuthorizer() autorest.Authorizer {
 }
 
 // CheckIsOwner returns if the given objectId is assigned Owner role on the given subscription
-func CheckIsOwner(objectID string, subID string) (bool, error) {
+func CheckIsOwner(objectID string, subID string, tenantID string) (bool, error) {
 	client := authorization.NewRoleAssignmentsClient(subID)
 	client.Authorizer = GetAuthorizer()
 	targetSubscriptionResourceID := fmt.Sprintf("/subscriptions/%s", subID)
-	resultPages, err := client.ListForScope(context.Background(), targetSubscriptionResourceID, fmt.Sprintf("assignedTo('%s')", objectID))
+	resultPages, err := client.ListForScope(context.Background(), targetSubscriptionResourceID, fmt.Sprintf("assignedTo('%s')", objectID), tenantID)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/azure/auth_test.go
+++ b/pkg/azure/auth_test.go
@@ -14,16 +14,17 @@ func Test_IsOwnerCLI(t *testing.T) {
 	i := GetSignedInIdentity()
 	s := GetSubscription()
 
-	isOwner, err := CheckIsOwner(i.ObjectID, s.ID)
+	isOwner, err := CheckIsOwner(i.ObjectID, s.ID, s.TenantID)
 	assert.Nil(t, err)
 	assert.True(t, isOwner)
 }
 
 func Test_IsNotOwnerSub(t *testing.T) {
 	i := GetSignedInIdentity()
+	s := GetSubscription()
 
 	// Random GUID for subscription
-	isOwner, err := CheckIsOwner(i.ObjectID, "63f3ec63-61c7-432c-9a10-9513ec3f889e")
+	isOwner, err := CheckIsOwner(i.ObjectID, "63f3ec63-61c7-432c-9a10-9513ec3f889e", s.TenantID)
 	// This will error with 404
 	assert.NotNil(t, err)
 	detailedErr := err.(autorest.DetailedError)
@@ -35,7 +36,7 @@ func Test_IsNotOwnerOID(t *testing.T) {
 	s := GetSubscription()
 
 	// Random GUID for object id
-	isOwner, err := CheckIsOwner("5e441a4a-1da9-4f8e-8022-bd9debec9cc3", s.ID)
+	isOwner, err := CheckIsOwner("5e441a4a-1da9-4f8e-8022-bd9debec9cc3", s.ID, s.TenantID)
 	assert.Nil(t, err)
 	assert.False(t, isOwner)
 }

--- a/pkg/azure/cli.go
+++ b/pkg/azure/cli.go
@@ -41,11 +41,6 @@ type signedInUserIdentity struct {
 	DisplayName       string
 }
 
-type userAssignedIdentityIDs struct {
-	ClientID    string `json:"clientID,omitempty"`
-	PrincipalID string `json:"principalID,omitempty"`
-}
-
 // VMIdentity is the output of 'az vm identity show'
 type VMIdentity struct {
 	PrincipalID            string                     `json:"principalID,omitempty"`

--- a/pkg/landingzone/landingzone.go
+++ b/pkg/landingzone/landingzone.go
@@ -162,12 +162,13 @@ func getIndentity(acct azure.Subscription, targetSubID string) azure.Identity {
 		}
 
 		metadata := azure.VMInstanceMetadataService()
-		vmIdentities := azure.GetVMIdentities(metadata.Compute.ResourceGroupName, metadata.Compute.Name)
+		vmIdentities, err := azure.GetVMIdentities(acct.ID, metadata.Compute.ResourceGroupName, metadata.Compute.Name)
+		cobra.CheckErr(err)
 
 		// look for the vm identity that matches the az login id
 		// it could be a system assigned (AssignedIdentityInfo="MSI")
 		// it could be a user assigned (AssignedIdentityInfo="MSIObject" or "MSIClient")
-		for _, id := range vmIdentities.IDList {
+		for _, id := range vmIdentities {
 
 			if systemAssigned {
 				if id.DisplayName == "SystemAssigned" {
@@ -213,7 +214,7 @@ func (o *Options) runLaunchpadInit(tf *tfexec.Terraform, reconfigure bool) error
 
 	console.StartSpinner()
 	// Validate that the indentity we are using is owner on subscription, not sure why but it's in rover v1 code
-	isOwner, err := azure.CheckIsOwner(o.Identity.ObjectID, o.StateSubscription)
+	isOwner, err := azure.CheckIsOwner(o.Identity.ObjectID, o.StateSubscription, o.Subscription.TenantID)
 	cobra.CheckErr(err)
 	if !isOwner {
 		console.StopSpinner()


### PR DESCRIPTION
Changes
 - azure.GetVMIdentities() moved to vm.go and now uses the Go SDK for Azure rather than calling the CLI
 - SIDE EFFECT: Azure SDK update when running go mod tidy brough in new version, now tenant ID must be passed to ListForScope used by azure.CheckIsOwner(). This was not originally in scope for this PR
 
Fixes #114 