### PR TITLE
Switch custom actions to being a single file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,7 +60,7 @@ func init() {
 	// Find and load in custom actions
 	custActions, err := custom.FetchActions()
 	if err != nil {
-		console.Errorf("Failed %s", err)
+		console.Errorf("Loading custom actions failed: %s\n", err)
 		os.Exit(1)
 	}
 	for _, ca := range custActions {

--- a/pkg/custom/action_custom.go
+++ b/pkg/custom/action_custom.go
@@ -38,7 +38,7 @@ func newCustomAction(name string, cad actionDefinition) Action {
 		command: cad,
 		ActionBase: landingzone.ActionBase{
 			Name:        name,
-			Description: cad.Description,
+			Description: cad.Description + " [Custom]",
 		},
 	}
 }

--- a/pkg/custom/default_actions.yaml
+++ b/pkg/custom/default_actions.yaml
@@ -1,0 +1,15 @@
+#
+# Rover custom actions definitions for running external tools
+#
+
+# This is provided as an example
+finder:
+  executable: "find"
+  description: "List all terraform (example custom action)"
+  arguments: ["{{SOURCE_DIR}}", "-name", "*.tf"]
+
+# This runs tflint
+lint:
+  executable: "tflint"
+  description: "A linter for terraform"
+  arguments: ["{{SOURCE_DIR}}", "--enable-rule=terraform_comment_syntax"]

--- a/pkg/custom/default_actions.yaml
+++ b/pkg/custom/default_actions.yaml
@@ -5,7 +5,7 @@
 # This is provided as an example
 finder:
   executable: "find"
-  description: "List all terraform (example custom action)"
+  description: "List all terraform"
   arguments: ["{{SOURCE_DIR}}", "-name", "*.tf"]
 
 # This runs tflint


### PR DESCRIPTION
As a side effect of the work on #109 and #122 it has been decided to change the design of custom actions

Instead of a directory containing multiple YAML files, a single YAML file is used. This simplifies the code _significantly_, it is also felt this will give an easier/better user experience also.

The file used resides in the `$HOME/.rover/` directory and is named `actions.yaml`.
When rover starts this file is checked, if it doesn't exist a default is created, see pkg/custom/default_actions.yaml Note: The contents of this default file are embedded into the rover binary at build time

Example of actions.yaml
Note there is no longer a need for a `name:` field, the YAML key is used as the action name
```yaml
finder:
  executable: "find"
  description: "List all terraform (example custom action)"
  arguments: ["{{SOURCE_DIR}}", "-name", "*.tf"]

lint:
  executable: "tflint"
  description: "A linter for terraform"
  arguments: ["{{SOURCE_DIR}}", "--enable-rule=terraform_comment_syntax"]
```

All other functionality remains the same