### PR TITLE
Paul d foster/issue64

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -132,18 +132,5 @@ func init() {
 
 		// Stuff it under the parent root command
 		rootCmd.AddCommand(actionSubCmd)
-		logger.OpenCommandLog("Init")
-		logger.WithFields(logger.Fields{"t": "1"}).Error("111")
-		logger.WithFields(logger.Fields{"t": "2"}).Info("111")
-		logger.OpenCommandLog("Plan")
-		logger.Trace("Trace 1")
-		logger.Debug("Debug 1")
-		logger.OpenCommandLog("Apply")
-		logger.Info("Info 1")
-		logger.Warn("Warn 1")
-		logger.OpenCommandLog("TFLint")
-		logger.Warning("Warning 1")
-		logger.Error("Error 1")
-		logger.CloseCommandLog()
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,8 +39,7 @@ It acts as a toolchain development environment to avoid impacting the local mach
 to make sure that all contributors in the GitOps teams are using a consistent set of tools and version.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		console.DebugEnabled, _ = cmd.Flags().GetBool("debug")
-		logger.SetLogLevel(cmd.Flags().GetString("log-level"))
-		logger.LogEnvironment, _ = cmd.Flags().GetString("environment")
+		logger.SetLogLevel(cmd.Flags().GetString("log-severity"))
 	},
 }
 
@@ -57,8 +56,7 @@ func GetVersion() string {
 
 func init() {
 	rootCmd.PersistentFlags().Bool("debug", false, "log extra debug information, may contain secrets")
-	rootCmd.PersistentFlags().String("environment", "development", "set logging environment production|development")
-	rootCmd.PersistentFlags().String("log-level", "info", "set log level trace|debug|info|warn|error|fatal|panic")
+	rootCmd.PersistentFlags().String("log-severity", "info", "set log level trace|debug|info|warn|error|fatal|panic")
 
 	command.ValidateDependencies()
 
@@ -134,5 +132,17 @@ func init() {
 
 		// Stuff it under the parent root command
 		rootCmd.AddCommand(actionSubCmd)
+		logger.SetCommand("Init")
+		logger.WithFields(logger.Fields{"t": "1"}).Error("111")
+		logger.WithFields(logger.Fields{"t": "2"}).Info("111")
+		logger.SetCommand("Plan")
+		logger.Trace("Trace 1")
+		logger.Debug("Debug 1")
+		logger.SetCommand("Apply")
+		logger.Info("Info 1")
+		logger.Warn("Warn 1")
+		logger.SetCommand("TFLint")
+		logger.Warning("Warning 1")
+		logger.Error("Error 1")
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aztfmod/rover/pkg/console"
 	"github.com/aztfmod/rover/pkg/custom"
 	"github.com/aztfmod/rover/pkg/landingzone"
+	"github.com/aztfmod/rover/pkg/logger"
 	"github.com/aztfmod/rover/pkg/symphony"
 	"github.com/aztfmod/rover/pkg/version"
 	"github.com/spf13/cobra"
@@ -38,6 +39,8 @@ It acts as a toolchain development environment to avoid impacting the local mach
 to make sure that all contributors in the GitOps teams are using a consistent set of tools and version.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		console.DebugEnabled, _ = cmd.Flags().GetBool("debug")
+		logger.SetLogLevel(cmd.Flags().GetString("log-level"))
+		logger.LogEnvironment, _ = cmd.Flags().GetString("environment")
 	},
 }
 
@@ -54,6 +57,8 @@ func GetVersion() string {
 
 func init() {
 	rootCmd.PersistentFlags().Bool("debug", false, "log extra debug information, may contain secrets")
+	rootCmd.PersistentFlags().String("environment", "development", "set logging environment production|development")
+	rootCmd.PersistentFlags().String("log-level", "info", "set log level trace|debug|info|warn|error|fatal|panic")
 
 	command.ValidateDependencies()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -132,17 +132,18 @@ func init() {
 
 		// Stuff it under the parent root command
 		rootCmd.AddCommand(actionSubCmd)
-		logger.SetCommand("Init")
+		logger.OpenCommandLog("Init")
 		logger.WithFields(logger.Fields{"t": "1"}).Error("111")
 		logger.WithFields(logger.Fields{"t": "2"}).Info("111")
-		logger.SetCommand("Plan")
+		logger.OpenCommandLog("Plan")
 		logger.Trace("Trace 1")
 		logger.Debug("Debug 1")
-		logger.SetCommand("Apply")
+		logger.OpenCommandLog("Apply")
 		logger.Info("Info 1")
 		logger.Warn("Warn 1")
-		logger.SetCommand("TFLint")
+		logger.OpenCommandLog("TFLint")
 		logger.Warning("Warning 1")
 		logger.Error("Error 1")
+		logger.CloseCommandLog()
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/briandowns/spinner v1.13.0
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-exec v0.13.3
+	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea // indirect

--- a/go.sum
+++ b/go.sum
@@ -297,6 +297,8 @@ github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNX
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/pkg/logger/entry.go
+++ b/pkg/logger/entry.go
@@ -1,0 +1,19 @@
+package logger
+
+import "github.com/sirupsen/logrus"
+
+type Entry Fields
+
+func (logFields *Entry) Error(args ...interface{}) {
+	f := logrus.Fields(*logFields)
+	fileEntry := fileLog.WithFields(f)
+	stdOutLog.WithFields(logrus.Fields{"For details see": currentFile}).Error(args...)
+	fileEntry.Error(args...)
+}
+
+func (logFields *Entry) Info(message string) {
+	f := logrus.Fields(*logFields)
+	fileEntry := fileLog.WithFields(f)
+	stdOutLog.Info(message)
+	fileEntry.Info(message)
+}

--- a/pkg/logger/entry.go
+++ b/pkg/logger/entry.go
@@ -10,8 +10,44 @@ func (logFields *Entry) Error(args ...interface{}) {
 	fileEntry.Error(args...)
 }
 
+func (logFields *Entry) Fatal(args ...interface{}) {
+	fileEntry := fileLog.WithFields(logrus.Fields(*logFields))
+	stdOutLog.WithFields(logrus.Fields{"Fatal error encounterewd. For details see": currentFile}).Error(args...)
+	fileEntry.Fatal(args...)
+}
+
+func (logFields *Entry) Panic(args ...interface{}) {
+	fileEntry := fileLog.WithFields(logrus.Fields(*logFields))
+	stdOutLog.WithFields(logrus.Fields{"For details see": currentFile}).Panic(args...)
+	fileEntry.Panic(args...)
+}
+
+func (logFields *Entry) Trace(message string) {
+	fileEntry := fileLog.WithFields(logrus.Fields(*logFields))
+	stdOutLog.Trace(message)
+	fileEntry.Trace(message)
+}
+
+func (logFields *Entry) Debug(message string) {
+	fileEntry := fileLog.WithFields(logrus.Fields(*logFields))
+	stdOutLog.Debug(message)
+	fileEntry.Debug(message)
+}
+
 func (logFields *Entry) Info(message string) {
 	fileEntry := fileLog.WithFields(logrus.Fields(*logFields))
 	stdOutLog.Info(message)
 	fileEntry.Info(message)
+}
+
+func (logFields *Entry) Warn(message string) {
+	fileEntry := fileLog.WithFields(logrus.Fields(*logFields))
+	stdOutLog.Warn(message)
+	fileEntry.Warn(message)
+}
+
+func (logFields *Entry) Warning(message string) {
+	fileEntry := fileLog.WithFields(logrus.Fields(*logFields))
+	stdOutLog.Warning(message)
+	fileEntry.Warning(message)
 }

--- a/pkg/logger/entry.go
+++ b/pkg/logger/entry.go
@@ -5,15 +5,13 @@ import "github.com/sirupsen/logrus"
 type Entry Fields
 
 func (logFields *Entry) Error(args ...interface{}) {
-	f := logrus.Fields(*logFields)
-	fileEntry := fileLog.WithFields(f)
+	fileEntry := fileLog.WithFields(logrus.Fields(*logFields))
 	stdOutLog.WithFields(logrus.Fields{"For details see": currentFile}).Error(args...)
 	fileEntry.Error(args...)
 }
 
 func (logFields *Entry) Info(message string) {
-	f := logrus.Fields(*logFields)
-	fileEntry := fileLog.WithFields(f)
+	fileEntry := fileLog.WithFields(logrus.Fields(*logFields))
 	stdOutLog.Info(message)
 	fileEntry.Info(message)
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/aztfmod/rover/pkg/command"
-	"github.com/aztfmod/rover/pkg/console"
 	"github.com/aztfmod/rover/pkg/utils"
 	"github.com/sirupsen/logrus"
 )
@@ -20,12 +19,8 @@ var currentFile string
 
 type Fields = map[string]interface{}
 
-// Only supporting fields on file logging because can only return one value
-func WithFields(fields Fields) *logrus.Entry {
-	stdOutEntry = stdOutLog.WithFields(fields) // Saves an Entry with fields
-	// Issue: Don't know log level of command (if one is used), so can't log stdout at correct level
-	console.Infof("Level: %d", stdOutEntry.Level) // this is 0, not set (because it hasn't be logged at a level yet?)
-	return fileLog.WithFields(fields)             // This passes the entry for filelog back to the Entry function in the code line
+func WithFields(fields Fields) *Entry {
+	return (*Entry)(&fields)
 }
 
 func Trace(args ...interface{}) {
@@ -44,13 +39,7 @@ func Print(args ...interface{}) {
 }
 
 func Info(args ...interface{}) {
-	if stdOutEntry == nil {
-		console.Info("stdOutEntry is nil")
-		stdOutLog.Info(args...)
-	} else {
-		console.Info("stdOutEntry is not nil")
-		stdOutEntry.Info(args...)
-	}
+	stdOutLog.Info(args...)
 	fileLog.Info(args...)
 }
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -92,7 +92,7 @@ func init() {
 
 	fileLog.SetLevel(logLevel)
 	fileLog.SetFormatter(&logrus.JSONFormatter{})
-	SetCommand("rover")
+	setCommand("rover")
 }
 
 func SetLogLevel(level string, err error) {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -4,61 +4,139 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/aztfmod/rover/pkg/command"
+	"github.com/aztfmod/rover/pkg/console"
 	"github.com/aztfmod/rover/pkg/utils"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
-var LogEnvironment = "production"
-var logLevel = log.InfoLevel
+var stdOutLog = logrus.New()
+var stdOutEntry *logrus.Entry
+var fileLog = logrus.New()
+var logLevel = logrus.InfoLevel
+var currentFile string
+
+type Fields = map[string]interface{}
+
+// Only supporting fields on file logging
+func WithFields(fields Fields) *logrus.Entry {
+	stdOutEntry = stdOutLog.WithFields(fields)
+	console.Infof("Level: %d", stdOutEntry.Level)
+	return fileLog.WithFields(fields)
+}
+
+func Trace(args ...interface{}) {
+	stdOutLog.Trace(args...)
+	fileLog.Trace(args...)
+}
+
+func Debug(args ...interface{}) {
+	stdOutLog.Debug(args...)
+	fileLog.Debug(args...)
+}
+
+func Print(args ...interface{}) {
+	stdOutLog.Print(args...)
+	fileLog.Print(args...)
+}
+
+func Info(args ...interface{}) {
+	if stdOutEntry == nil {
+		console.Info("stdOutEntry is nil")
+		stdOutLog.Info(args...)
+	} else {
+		console.Info("stdOutEntry is not nil")
+		stdOutEntry.Info(args...)
+	}
+	fileLog.Info(args...)
+}
+
+func Warn(args ...interface{}) {
+	stdOutLog.Warn(args...)
+	fileLog.Warn(args...)
+}
+
+func Warning(args ...interface{}) {
+	stdOutLog.Warning(args...)
+	fileLog.Warning(args...)
+}
+
+func Error(args ...interface{}) {
+	stdOutLog.WithFields(logrus.Fields{"For details see": currentFile}).Error(args...)
+	fileLog.Error(args...)
+}
+
+func Panic(args ...interface{}) {
+	stdOutLog.WithFields(logrus.Fields{"For details see": currentFile}).Panic(args...)
+	fileLog.Panic(args...)
+}
+
+func Fatal(args ...interface{}) {
+	//stdOutLog.Fatal(args...) - fatal calls Exit(1)
+	stdOutLog.WithFields(logrus.Fields{"Fatal error encounterewd. For details see": currentFile}).Error(args...)
+	fileLog.Fatal(args...) // So logging to file only
+}
 
 func init() {
-	log.SetFormatter(&log.TextFormatter{
+	stdOutLog.SetFormatter(&logrus.TextFormatter{
 		ForceColors:      true,
 		DisableColors:    false,
 		FullTimestamp:    false,
 		DisableTimestamp: true,
 	})
+	stdOutLog.SetLevel(logrus.InfoLevel)
+	stdOutLog.SetOutput(os.Stdout)
 
-	log.SetLevel(logLevel)
-
-	if LogEnvironment == "production" {
-		log.SetFormatter(&log.JSONFormatter{})
-		roverHomeDir, _ := utils.GetRoverDirectory()
-		roverHomeLogsDir := filepath.Join(roverHomeDir, "logs")
-		command.EnsureDirectory(roverHomeLogsDir)
-		roverLogFile := filepath.Join(roverHomeLogsDir, "rover.log")
-		file, err := os.OpenFile(roverLogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
-		if err == nil {
-			log.SetOutput(file)
-		} else {
-			log.Info("Failed to log to file, using default stderr")
-		}
-	} else {
-		log.SetReportCaller(true) // has performance impact but useful in debugging
-	}
-
+	fileLog.SetLevel(logLevel)
+	fileLog.SetFormatter(&logrus.JSONFormatter{})
+	SetCommand("rover")
 }
 
 func SetLogLevel(level string, err error) {
 	lowerLevel := strings.ToLower(level)
 	switch lowerLevel {
 	case "trace":
-		logLevel = log.TraceLevel
+		logLevel = logrus.TraceLevel
 	case "debug":
-		logLevel = log.DebugLevel
+		logLevel = logrus.DebugLevel
 	case "info":
-		logLevel = log.InfoLevel
+		logLevel = logrus.InfoLevel
 	case "warn":
-		logLevel = log.WarnLevel
+		logLevel = logrus.WarnLevel
 	case "error":
-		logLevel = log.ErrorLevel
+		logLevel = logrus.ErrorLevel
 	case "fatal":
-		logLevel = log.FatalLevel
+		logLevel = logrus.FatalLevel
 	case "panic":
-		logLevel = log.PanicLevel
+		logLevel = logrus.PanicLevel
 	default:
-		logLevel = log.InfoLevel
+		logLevel = logrus.InfoLevel
+	}
+	fileLog.SetLevel(logLevel)
+}
+
+func SetCommand(rovercommand string) {
+
+	rovercommand = strings.ReplaceAll(rovercommand, " ", "")
+	if rovercommand == "" {
+		rovercommand = "rover"
+	}
+
+	roverHomeDir, _ := utils.GetRoverDirectory()
+	roverHomeLogsDir := filepath.Join(roverHomeDir, "logs")
+	command.EnsureDirectory(roverHomeLogsDir)
+
+	// Add datetime stamp to filename
+	currentTime := time.Now()
+	currentFile = rovercommand + "--" + currentTime.Format("2006-01-02--15-04") + ".log"
+
+	roverLogFile := filepath.Join(roverHomeLogsDir, currentFile)
+	file, err := os.OpenFile(roverLogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	if err == nil {
+		fileLog.SetOutput(file)
+	} else {
+		stdOutLog.Info("Failed to log to file, using default stderr")
 	}
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,64 @@
+package logger
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aztfmod/rover/pkg/command"
+	"github.com/aztfmod/rover/pkg/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+var LogEnvironment = "production"
+var logLevel = log.InfoLevel
+
+func init() {
+	log.SetFormatter(&log.TextFormatter{
+		ForceColors:      true,
+		DisableColors:    false,
+		FullTimestamp:    false,
+		DisableTimestamp: true,
+	})
+
+	log.SetLevel(logLevel)
+
+	if LogEnvironment == "production" {
+		log.SetFormatter(&log.JSONFormatter{})
+		roverHomeDir, _ := utils.GetRoverDirectory()
+		roverHomeLogsDir := filepath.Join(roverHomeDir, "logs")
+		command.EnsureDirectory(roverHomeLogsDir)
+		roverLogFile := filepath.Join(roverHomeLogsDir, "rover.log")
+		file, err := os.OpenFile(roverLogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+		if err == nil {
+			log.SetOutput(file)
+		} else {
+			log.Info("Failed to log to file, using default stderr")
+		}
+	} else {
+		log.SetReportCaller(true) // has performance impact but useful in debugging
+	}
+
+}
+
+func SetLogLevel(level string, err error) {
+	lowerLevel := strings.ToLower(level)
+	switch lowerLevel {
+	case "trace":
+		logLevel = log.TraceLevel
+	case "debug":
+		logLevel = log.DebugLevel
+	case "info":
+		logLevel = log.InfoLevel
+	case "warn":
+		logLevel = log.WarnLevel
+	case "error":
+		logLevel = log.ErrorLevel
+	case "fatal":
+		logLevel = log.FatalLevel
+	case "panic":
+		logLevel = log.PanicLevel
+	default:
+		logLevel = log.InfoLevel
+	}
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -20,11 +20,11 @@ var currentFile string
 
 type Fields = map[string]interface{}
 
-// Only supporting fields on file logging
+// Only supporting fields on file logging because can only return one value
 func WithFields(fields Fields) *logrus.Entry {
 	stdOutEntry = stdOutLog.WithFields(fields) // Saves an Entry with fields
 	// Issue: Don't know log level of command (if one is used), so can't log stdout at correct level
-	console.Infof("Level: %d", stdOutEntry.Level) // this is 0, not set
+	console.Infof("Level: %d", stdOutEntry.Level) // this is 0, not set (because it hasn't be logged at a level yet?)
 	return fileLog.WithFields(fields)             // This passes the entry for filelog back to the Entry function in the code line
 }
 
@@ -118,7 +118,15 @@ func SetLogLevel(level string, err error) {
 	fileLog.SetLevel(logLevel)
 }
 
-func SetCommand(rovercommand string) {
+func OpenCommandLog(rovercommand string) {
+	setCommand(rovercommand)
+}
+
+func CloseCommandLog() {
+	setCommand("")
+}
+
+func setCommand(rovercommand string) {
 
 	rovercommand = strings.ReplaceAll(rovercommand, " ", "")
 	if rovercommand == "" {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -12,7 +12,6 @@ import (
 )
 
 var stdOutLog = logrus.New()
-var stdOutEntry *logrus.Entry
 var fileLog = logrus.New()
 var logLevel = logrus.InfoLevel
 var currentFile string

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -22,9 +22,10 @@ type Fields = map[string]interface{}
 
 // Only supporting fields on file logging
 func WithFields(fields Fields) *logrus.Entry {
-	stdOutEntry = stdOutLog.WithFields(fields)
-	console.Infof("Level: %d", stdOutEntry.Level)
-	return fileLog.WithFields(fields)
+	stdOutEntry = stdOutLog.WithFields(fields) // Saves an Entry with fields
+	// Issue: Don't know log level of command (if one is used), so can't log stdout at correct level
+	console.Infof("Level: %d", stdOutEntry.Level) // this is 0, not set
+	return fileLog.WithFields(fields)             // This passes the entry for filelog back to the Entry function in the code line
 }
 
 func Trace(args ...interface{}) {


### PR DESCRIPTION
Asking for feedback.

This PR implements a logging facade over the logrus logging package so that the goal of having two log resources (stdout, file) can be implemented such that each log resource can have a different log severity. The implementation supports logrus's structured logging approach using the WithFields method to add key/value pairs rather than have them embedded in printf style messaging.

Additionally, this PR implements the ability to have a different log for each rover command executed. This is achieved by setting the command at the beginning of command execution and closing the command at the end.

StdOut logging uses a text formatter with colours.
File logging uses a JSON formatter for machine processing.

StdOut log severity is set to Info
File log severity is set for info unless set by the command line switch --log-severity <string>

Example usage:
		logger.OpenCommandLog("Init")
		logger.WithFields(logger.Fields{"t": "1"}).Error("111")
		logger.WithFields(logger.Fields{"t": "2"}).Info("111")
		logger.OpenCommandLog("Plan")
		logger.Trace("Trace 1")
		logger.Debug("Debug 1")
		logger.OpenCommandLog("Apply")
		logger.Info("Info 1")
		logger.Warn("Warn 1")
		logger.OpenCommandLog("TFLint")
		logger.Warning("Warning 1")
		logger.Error("Error 1")
		logger.CloseCommandLog()

  