### PR TITLE
update to reference the dockerfile

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,9 @@
   // Intended for Rover maintainers only
   //
   "name": "Rover v2 Dev",
-  "image": "symphonydev.azurecr.io/rover2-dev:latest",
+  //"image": "symphonydev.azurecr.io/rover2-dev:latest",
+  "build": {
+    "dockerfile": "Dockerfile"},
   "remoteUser": "rover",
   "runArgs": ["--init"],
   // TODO: This needs more work, see https://github.com/microsoft/vscode-dev-containers/tree/main/containers/docker-from-docker#enabling-non-root-access-to-docker-in-the-container
@@ -18,7 +20,7 @@
     },
     "terminal.integrated.defaultProfile.linux": "zsh"
   },
-  "postStartCommand": "go mod tidy && go get -v golang.org/x/tools/gopls",
+  "postStartCommand": "go mod tidy && go get -v golang.org/x/tools/gopls && go install github.com/go-delve/delve/cmd/dlv@master",
   "extensions": [
     "Gruntfuggly.todo-tree",
     "golang.go",


### PR DESCRIPTION
As a developer, I want to ensure I can open RoverGo in a DevContainer, so that I can easily contribute to the project.

Currently the DevContainer defined in the repo is invalid. It references an image that is not in the symphony dev ACR. Even after moving to an image on symphonydev, the container fails to load.

The story is part of the developer experience for RoverGo. We need to ensure that the DevContainer loads on VSCode and that a user is able to build and debug in a dev container.
