### PR TITLE
Update  cmd path to support cross platform

### DIFF
--- a/cmd/landingzone_fetch.go
+++ b/cmd/landingzone_fetch.go
@@ -9,6 +9,7 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
+	"path"
 	"strconv"
 	"strings"
 
@@ -58,7 +59,7 @@ func runFetch(repo string, branch string, strip int, dest string, subFolder stri
 	console.Infof("Running fetch operation. Will download %s branch of %s and place into %s\n", branch, repo, dest)
 
 	cloneURL := fmt.Sprintf("%s/%s/tar.gz/%s", gitBase, repo, branch)
-	tarFile := fmt.Sprintf("%s/%s", tempDir, tempFileName)
+	tarFile := path.Join(tempDir, tempFileName)
 
 	projParts := strings.Split(repo, "/")
 	if len(projParts) < 2 {

--- a/pkg/landingzone/action_apply.go
+++ b/pkg/landingzone/action_apply.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/aztfmod/rover/pkg/azure"
 	"github.com/aztfmod/rover/pkg/console"
@@ -34,8 +35,8 @@ func (a *ApplyAction) Execute(o *Options) error {
 		return err
 	}
 
-	planFile := fmt.Sprintf("%s/%s.tfplan", o.DataDir, o.StateName)
-	stateFile := fmt.Sprintf("%s/%s.tfstate", o.DataDir, o.StateName)
+	planFile := path.Join(o.DataDir, fmt.Sprintf("%s.tfplan", o.StateName))
+	stateFile := path.Join(o.DataDir, fmt.Sprintf("%s.tfstate", o.StateName))
 	console.Infof("Apply will use plan file %s\n", planFile)
 
 	// Build apply options, with plan file and state out

--- a/pkg/landingzone/action_destroy.go
+++ b/pkg/landingzone/action_destroy.go
@@ -2,7 +2,9 @@ package landingzone
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"path"
 
 	"github.com/aztfmod/rover/pkg/azure"
 	"github.com/aztfmod/rover/pkg/console"
@@ -38,7 +40,7 @@ func (a *DestroyAction) Execute(o *Options) error {
 		return nil
 	}
 
-	stateFileName := o.DataDir + "/" + o.StateName + ".tfstate"
+	stateFileName := path.Join(o.DataDir, fmt.Sprintf("%s.tfstate", o.StateName))
 
 	// Build apply options, with plan file and state out
 	destroyOptions := []tfexec.DestroyOption{

--- a/pkg/landingzone/action_plan.go
+++ b/pkg/landingzone/action_plan.go
@@ -3,6 +3,7 @@ package landingzone
 import (
 	"context"
 	"fmt"
+	"path"
 
 	"github.com/aztfmod/rover/pkg/console"
 	"github.com/aztfmod/rover/pkg/terraform"
@@ -46,7 +47,7 @@ func (a *PlanAction) Execute(o *Options) error {
 	}
 
 	// Build plan options starting with tfplan output
-	planFile := fmt.Sprintf("%s/%s.tfplan", o.DataDir, o.StateName)
+	planFile := path.Join(o.DataDir, fmt.Sprintf("%s.tfplan", o.StateName))
 	planOptions := []tfexec.PlanOption{
 		tfexec.Out(planFile),
 		tfexec.Refresh(true),

--- a/pkg/landingzone/landingzone.go
+++ b/pkg/landingzone/landingzone.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -137,8 +138,8 @@ func (o *Options) SetupEnvironment() error {
 	os.Setenv("ARM_SUBSCRIPTION_ID", o.TargetSubscription)
 	os.Setenv("ARM_TENANT_ID", o.Subscription.TenantID)
 	os.Setenv("TF_VAR_tfstate_subscription_id", o.StateSubscription)
-	os.Setenv("TF_VAR_tf_name", fmt.Sprintf("%s.tfstate", o.StateName))
-	os.Setenv("TF_VAR_tf_plan", fmt.Sprintf("%s.tfplan", o.StateName))
+	os.Setenv("TF_VAR_tf_name", path.Join(o.StateName, ".tfstate"))
+	os.Setenv("TF_VAR_tf_plan", path.Join(o.StateName, ".tfplan"))
 	os.Setenv("TF_VAR_workspace", o.Workspace)
 	os.Setenv("TF_VAR_level", o.Level)
 	os.Setenv("TF_VAR_environment", o.CafEnvironment)


### PR DESCRIPTION
Rover actions are using string concatention to build paths ("file" + "/" + folder) . this PR updated the code to use path.join to be cross os.